### PR TITLE
README Side Logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-![logo](./static/icon.png)
+# Sunroof [<img src="./static/icon.png" width="225" align="right" alt="Sunroof">](https://github.com/verticalsync/Sunroof)
 
-# Sunroof
-
-[![Sunroof](https://img.shields.io/badge/Suncord-orange?style=flat)](https://github.com/verticalsync/Suncord)
+[![Suncord](https://img.shields.io/badge/Suncord-yellow?style=flat)](https://github.com/verticalsync/Suncord)
 [![Tests](https://github.com/verticalsync/Sunroof/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/verticalsync/Sunroof/actions/workflows/test.yml)
 [![Discord](https://img.shields.io/discord/1207691698386501634.svg?color=768AD4&label=Discord&logo=discord&logoColor=white)](https://discord.gg/VasF3Ma4Ab)
 
 Sunroof is a fork of [Vesktop](https://github.com/Vencord/Vesktop).
+
+You can join our [discord server](https://discord.gg/VasF3Ma4Ab) for commits, changes, chat or even support.<br></br> 
+
 
 ## Main features
 - Much more lightweight and faster than the official Discord app
@@ -19,8 +20,6 @@ Sunroof is a fork of [Vesktop](https://github.com/Vencord/Vesktop).
 **Not yet supported**:
 - Global Keybinds
   
-
-You can join our [discord server](https://discord.gg/VasF3Ma4Ab) for commits, changes, chat or even support.
 
 ## Installing
 


### PR DESCRIPTION
* Make the logo to the right side & Change Suncord badge color to yellow to match logo color.
 * had to use some `html`  for the logo not having a visible line placed incorrectly
 * new lines had to be made using `html` too due to weird github markdown logic, making new lines non-existent when adding them on that area
 * discord invite has been moved up to the description not look that empty

[before](https://capybara.love/ypyv4kk9.png)
[after](https://capybara.love/p5w34pyd.png)